### PR TITLE
Initial implementation of automated deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Backend tests and linter checks can be run using scripts:
 
 ```bash
 $ ./backend/scripts/test.sh
-$ ./backend/script/lint.sh
+$ ./backend/scripts/lint.sh
 ```
 
 In local environments, the generated HTML coverage report at `./backend/htmlcov/index.html` can be opened to view coverage details.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,25 @@
+# RAISE Management Application deployment
+
+## Overview
+
+This application is deployed using Kubernetes. The deployment is automated via [CodePipeline](https://docs.aws.amazon.com/codepipeline). This directory includes all deployment related configuration files used for the application, with the exception of the AWS infrastructure resource definitions which live with the rest of the k12 IaC code. The subdirectories include:
+
+* `buildspec/` - [CodeBuild](https://docs.aws.amazon.com/codebuild) buildspec files used in pipeline stages
+* `k8s/` - Kubernetes resource definitions
+
+In some cases, there is a coupling between these two whereby values in the Kubernetes resource definitions are patched during pipeline execution using [`yq`](https://mikefarah.gitbook.io/yq/). By convention, to make it easier to see which values are managed in this manner, the base definitions use `REPLACED_IN_PIPELINE`. If you need to deploy manually to a k8s cluster (either on AWS or a local [minikube](https://minikube.sigs.k8s.io/docs/)), you should modify these values locally before running `kubectl apply -R -f k8s` from this directory.
+
+This use of `yq` as a mechanism to patch resource definitions is intended to be used sparingly and should be limited to:
+
+* Secrets - The "source of truth" for our secrets is typically AWS SecretsManager. When deploying required secrets into k8s, we use the `buildspec` to pass / inject secrets automatically from SecretsManager into the cluster.
+
+* Dynamic values - Some variables are only determined during the context of a pipeline run (e.g. a Docker image tag), and we use the `buildspec` to splice those values in automatically.
+
+* Environment specific values where ConfigMaps don't apply - A current example of this is keeping `IngressRoute` definitions DRY since the matcher will vary depending upon the environment.
+
+In general, we should try to utilize k8s native alternatives such as [ConfigMaps](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1/) whenever possible.
+
+## References
+
+* [Build specification reference for CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html)
+* [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/)

--- a/deploy/buildspec/backend.yml
+++ b/deploy/buildspec/backend.yml
@@ -1,0 +1,24 @@
+version: 0.2
+
+env:
+  shell: bash
+  secrets-manager:
+    DOCKERHUB_USERNAME: "dockerhub:username"
+    DOCKERHUB_TOKEN: "dockerhub:token"
+
+phases:
+  pre_build:
+    commands:
+      - echo $DOCKERHUB_TOKEN | docker login --username $DOCKERHUB_USERNAME --password-stdin
+      - export IMAGE_TAG=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE_REPO_NAME:${COMMIT_ID:0:8}
+      - echo $IMAGE_TAG > backend-image-tag.txt
+  build:
+    commands:
+      - docker build backend/. -t $IMAGE_TAG
+  post_build:
+    commands:
+      - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+      - docker push $IMAGE_TAG
+artifacts:
+  files:
+    - backend-image-tag.txt

--- a/deploy/buildspec/deploy-dev.yml
+++ b/deploy/buildspec/deploy-dev.yml
@@ -1,0 +1,28 @@
+version: 0.2
+
+env:
+  shell: bash
+  secrets-manager:
+    POSTGRES_USER: "rds-raise-dev:username"
+    POSTGRES_PASSWORD: "rds-raise-dev:password"
+
+phases:
+  install:
+    commands:
+      - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+      - curl -L -o yq "https://github.com/mikefarah/yq/releases/download/v4.13.4/yq_linux_amd64"
+      - chmod +x ./kubectl ./yq
+      - export PATH=$PWD:$PATH
+  pre_build:
+    commands:
+      - aws eks update-kubeconfig --name $K8S_CLUSTER_NAME
+      - export BACKEND_IMAGE_TAG=$(cat $CODEBUILD_SRC_DIR_build_output/backend-image-tag.txt)
+      - export K8S_DIR=deploy/k8s
+      - yq e -i '.stringData.username=strenv(POSTGRES_USER)' $K8S_DIR/api/secret.yaml
+      - yq e -i '.stringData.password=strenv(POSTGRES_PASSWORD)' $K8S_DIR/api/secret.yaml
+      - yq e -i '.spec.template.spec.containers[0].image=strenv(BACKEND_IMAGE_TAG)' $K8S_DIR/api/deployment.yaml
+      - yq e -i '.spec.template.spec.containers[0].env[] |= select(.name=="POSTGRES_SERVER").value=strenv(POSTGRES_SERVER)' $K8S_DIR/api/deployment.yaml
+      - yq e -i '.spec.routes[].match="Host(`rma-dev.raise.openstax.org`) && PathPrefix(`/api`)"' $K8S_DIR/api/ingressroute.yaml
+  build:
+    commands:
+      - kubectl apply -R -f $K8S_DIR

--- a/deploy/k8s/api/deployment.yaml
+++ b/deploy/k8s/api/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rma-api
+  labels:
+    app: rma-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: rma-api
+  template:
+    metadata:
+      labels:
+        app: rma-api
+    spec:
+      containers:
+        - name: rma-backend
+          image: REPLACED_IN_PIPELINE
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rma-database-creds
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rma-database-creds
+                  key: password
+            - name: POSTGRES_DB
+              value: rma
+            - name: POSTGRES_SERVER
+              value: REPLACED_IN_PIPELINE
+          command:
+            - uvicorn
+          args:
+            - api.main:app
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "80"
+            - --root-path
+            - /api
+          ports:
+            - containerPort: 80

--- a/deploy/k8s/api/ingressroute.yaml
+++ b/deploy/k8s/api/ingressroute.yaml
@@ -1,0 +1,34 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: rma-api-tls
+spec:
+  entryPoints:
+    - websecure
+  tls:
+    secretName: rma-dev.raise.openstax.org-tls
+  routes:
+    - match: REPLACED_IN_PIPELINE
+      kind: Rule
+      middlewares:
+        - name: rma-api-strip-prefix
+      services:
+        - name: rma-api
+          port: 80
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: rma-api
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: REPLACED_IN_PIPELINE
+      kind: Rule
+      middlewares:
+        - name: rma-api-http-redirect
+      services:
+        - name: rma-api
+          port: 80

--- a/deploy/k8s/api/middleware.yaml
+++ b/deploy/k8s/api/middleware.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: rma-api-http-redirect
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: rma-api-strip-prefix
+spec:
+  stripPrefix:
+    prefixes:
+      - /api

--- a/deploy/k8s/api/secret.yaml
+++ b/deploy/k8s/api/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rma-database-creds
+type: Opaque
+stringData:
+  username: REPLACED_IN_PIPELINE
+  password: REPLACED_IN_PIPELINE

--- a/deploy/k8s/api/service.yaml
+++ b/deploy/k8s/api/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rma-api
+spec:
+  selector:
+    app: rma-api
+  ports:
+    - port: 80
+      targetPort: 80


### PR DESCRIPTION
This is a baseline pass that gets the major moving parts up and running for early development. It will automatically build and deploy code from `main` to a dev kubernetes cluster. The pipeline will be extended in the future as we flesh out processes and how we want things to work.